### PR TITLE
Fix project metadata.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__
 /output/*
 /build
 logs/
+*.egg-info/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,33 +1,32 @@
 [project]
 name = "wfc_python"
-version = "2019f"
+version = "0.0.0"
 description = "Implementation of wave function collapse in Python."
-authors = [
-    "Isaac Karth <isaac@isaackarth.com>"
-]
-license = "MIT"
 readme = "README.md"
-python = "^3.5"
-repository = "https://github.com/ikarth/wfc_python"
+requires-python = ">=3.5"
+license = {file = "LICENSE"}
 keywords = ["sample", "wfc", "wave function collapse"]
-
+authors = [{name = "Isaac Karth", email = "isaac@isaackarth.com"}]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Topic :: Utilities",
     "License :: OSI Approved :: MIT License",
 ]
 
-[build-system]
-
-requires = [
-    "setuptools",
+dependencies  = [
+    "hilbertcurve",
+    "imageio",
+    "matplotlib",
+    "numpy",
 ]
+
+[project.optional-dependencies]
+tests = ["pytest"]
+docs = ["sphinx"]
+
+[project.urls]
+homepage = "https://github.com/ikarth/wfc_python"
+
+[build-system]
+requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
-
-[dependencies]
-numpy
-imageio
-
-[dev-dependencies]
-pytest
-sphinx

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+numpy
+hilbertcurve
+imageio
+matplotlib
+
+pytest
+sphinx

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,11 @@
+[metadata]
+name = wfc_python
+version = 0.0.0
+
+[options]
+packages = wfc
+install_requires =
+    hilbertcurve
+    imageio
+    matplotlib
+    numpy


### PR DESCRIPTION
Missing requirements have been added to the metadata.  I've also added a `requirements.txt` file to simplify the process for casual developers.

Setuptools does not support pyproject yet, so I've added a `setup.cfg` file to hold basic information.

`pyproject.toml` was malformed, it now better matches up with [PEP 621](https://www.python.org/dev/peps/pep-0621/).

`2019f` is not a compliant version number.  Something like `2019.1.1` would work if you wanted to put a date as the version number, but if this won't be uploaded to PyPI then the version doesn't really matter.