### PR TITLE
Fix missing keyword in tests.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,6 @@ class Resources:
         return os.path.join(PROJECT_ROOT, "images", image)
 
 
-@pytest.fixture("session")
+@pytest.fixture(scope="session")
 def resources():
     return Resources()


### PR DESCRIPTION
The malformed `pyproject.toml` fixed by #3 also breaks pytest.